### PR TITLE
Added icon font package

### DIFF
--- a/lib/decorated_icon.dart
+++ b/lib/decorated_icon.dart
@@ -43,6 +43,7 @@ class DecoratedIcon extends StatelessWidget {
         fontSize: size,
         height: 1,
         inherit: false,
+        package: icon.fontPackage,
         shadows: shadows,
       ),
     );


### PR DESCRIPTION
Hello. First of all thanks for this useful plugin! 

I recently had a problem when using a custom icon from the [flutter_icons](https://pub.dev/packages/flutter_icons) plugin. When the icon `FontAwesome.plus_square` was given to the `DecoratedIcon` widget, the displayed icon was this:
<img width="31" alt="image" src="https://user-images.githubusercontent.com/34488374/106491209-adad0900-64c7-11eb-9880-913bbfb78bd3.png">

Upon further investigation I noticed that the icon's package was not set in the `Text` widget's `style`. Upon setting that using the icon's `fontPackage`, I was able to use 3rd party icons:
<img width="31" alt="image" src="https://user-images.githubusercontent.com/34488374/106491576-0ed4dc80-64c8-11eb-8f5c-e25b96a3a5cb.png">

I think this issue is due to Flutter defaulting to its own `fontPackage`, so a 3rd party icon could not be used and a default unknown icon would be displayed since the `fontPackage` would be incorrect.
