### PR TITLE
Make `DecoratedIcon` inherit `IconTheme` by default

### DIFF
--- a/lib/decorated_icon.dart
+++ b/lib/decorated_icon.dart
@@ -49,15 +49,16 @@ class DecoratedIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final iconDirection = textDirection ?? Directionality.of(context);
+    final iconTheme = IconTheme.of(context);
 
     Widget iconWidget = Text(
       String.fromCharCode(icon.codePoint),
       style: TextStyle(
-        color: color,
+        color: color ?? iconTheme.color,
         decoration: TextDecoration.none,
         fontFamily: icon.fontFamily,
         fontWeight: FontWeight.normal,
-        fontSize: size,
+        fontSize: size ?? iconTheme.size,
         height: 1,
         inherit: false,
         package: icon.fontPackage,


### PR DESCRIPTION
Closes #7.

This PR adds the ability to the `DecoratedIcon` widget to inherit the icon theme from the widget tree.

I think this is an essential feature of the widget, since it should behave as an `Icon` widget, not as a `Text` widget, even though is it.

Because the API, and overall functionality resembles an `Icon` widget, the theming aspect should as well.